### PR TITLE
Fix comment depth

### DIFF
--- a/Classes/HNKit/HNAPIRequestParser.m
+++ b/Classes/HNKit/HNAPIRequestParser.m
@@ -389,7 +389,7 @@ typedef enum {
             }
         } else {
             for (XMLElement *element2 in [element children]) {
-                if ([[element2 tagName] isEqual:@"img"] && [[element2 attributeWithName:@"src"] isEqualToString:@"s.gif"]) {
+                if ([[element2 tagName] isEqual:@"img"] && [[element2 attributeWithName:@"src"] hasSuffix:@"s.gif"]) {
                     // Yes, really: HN uses a 1x1 gif to indent comments. It's like 1999 all over again. :(
                     NSInteger width = [[element2 attributeWithName:@"width"] intValue];
                     // Each comment is "indented" by setting the width to "depth * 40", so divide to get the depth.


### PR DESCRIPTION
HN chaned the img src for the 1x1 gifs from this:
http://ycombinator.com/images/s.gif

to this:
s.gif

This fixes that check so comment depth is correctly determined.

I compiled the app with this fix and it appears to work just fine.
